### PR TITLE
[Edge] ハードウェア制御 (OLED, LED, ブザー, スイッチ) の実装 (Issue #5)

### DIFF
--- a/edge/platformio.ini
+++ b/edge/platformio.ini
@@ -6,3 +6,6 @@ monitor_speed = 115200
 lib_deps = 
 	tzapu/WiFiManager @ ^2.0.16-rc.2
 	bblanchon/ArduinoJson @ ^7.0.4
+	adafruit/Adafruit SSD1306 @ ^2.5.9
+	adafruit/Adafruit GFX Library @ ^1.11.9
+	thomasfredericks/Bounce2 @ ^2.72

--- a/edge/src/HardwareConfig.cpp
+++ b/edge/src/HardwareConfig.cpp
@@ -1,0 +1,116 @@
+#include "HardwareConfig.h"
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+#include <Wire.h>
+
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 64
+#define OLED_RESET -1 // Reset pin # (or -1 if sharing Arduino reset pin)
+
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
+
+// State internally used for blinking led
+static LedColor currentLedState = LED_OFF;
+static unsigned long lastBlinkTime = 0;
+static bool ledToggleState = false;
+
+void initHardware() {
+  // Initialize I2C for OLED
+  Wire.begin(I2C_SDA_PIN, I2C_SCL_PIN);
+  if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
+    Serial.println(F("SSD1306 allocation failed"));
+    // Try to proceed anyway
+  } else {
+    display.clearDisplay();
+    display.setTextSize(1);
+    display.setTextColor(SSD1306_WHITE);
+    display.setCursor(0, 0);
+    display.println("Initializing...");
+    display.display();
+  }
+
+  // Initialize LEDs
+  pinMode(LED_RED_PIN, OUTPUT);
+  pinMode(LED_BLUE_PIN, OUTPUT);
+  digitalWrite(LED_RED_PIN, LOW);
+  digitalWrite(LED_BLUE_PIN, LOW);
+
+  // Initialize Buzzer via PWM (ledc mechanism in ESP32)
+  ledcSetup(BUZZER_CHANNEL, BUZZER_FREQ, BUZZER_RES);
+  ledcAttachPin(BUZZER_PIN, BUZZER_CHANNEL);
+  ledcWrite(BUZZER_CHANNEL, 0); // Keep quiet initially
+}
+
+void displayStatus(const char *statusStr, const char *detailStr) {
+  display.clearDisplay();
+
+  display.setTextSize(2);
+  display.setTextColor(SSD1306_WHITE);
+  display.setCursor(0, 5);
+  display.println(statusStr);
+
+  if (detailStr && strlen(detailStr) > 0) {
+    display.setTextSize(1);
+    display.setCursor(0, 30);
+    display.println(detailStr);
+  }
+
+  display.display();
+}
+
+void displayError(const char *errorStr) {
+  display.clearDisplay();
+  display.setTextSize(1);
+  display.setTextColor(SSD1306_WHITE);
+  display.setCursor(0, 0);
+  display.println("--- ERROR ---");
+  display.setCursor(0, 20);
+  display.println(errorStr);
+  display.display();
+}
+
+void setLedState(LedColor color) {
+  currentLedState = color;
+  digitalWrite(LED_RED_PIN, LOW);
+  digitalWrite(LED_BLUE_PIN, LOW);
+
+  switch (color) {
+  case LED_RED:
+    digitalWrite(LED_RED_PIN, HIGH);
+    break;
+  case LED_BLUE:
+    digitalWrite(LED_BLUE_PIN, HIGH);
+    break;
+  case LED_BLUE_BLINK:
+    // Initial state is on, toggle logic handled in updateLedBlink()
+    digitalWrite(LED_BLUE_PIN, HIGH);
+    ledToggleState = true;
+    lastBlinkTime = millis();
+    break;
+  default:
+    break;
+  }
+}
+
+void updateLedBlink() {
+  if (currentLedState == LED_BLUE_BLINK) {
+    if (millis() - lastBlinkTime >= 500) { // Toggle every 500ms
+      lastBlinkTime = millis();
+      ledToggleState = !ledToggleState;
+      digitalWrite(LED_BLUE_PIN, ledToggleState ? HIGH : LOW);
+    }
+  }
+}
+
+void playBeep(int durationMs) {
+  ledcWrite(BUZZER_CHANNEL, 128); // 50% duty cycle
+  delay(durationMs);
+  ledcWrite(BUZZER_CHANNEL, 0);
+}
+
+void playErrorSound() {
+  for (int i = 0; i < 3; i++) {
+    playBeep(100);
+    delay(100);
+  }
+}

--- a/edge/src/HardwareConfig.h
+++ b/edge/src/HardwareConfig.h
@@ -1,0 +1,34 @@
+#ifndef HARDWARE_CONFIG_H
+#define HARDWARE_CONFIG_H
+
+#include <Arduino.h>
+
+// GPIO Definitions (based on target design)
+#define I2C_SDA_PIN 21
+#define I2C_SCL_PIN 22
+#define LED_RED_PIN 25
+#define LED_BLUE_PIN 26
+#define BUZZER_PIN 27
+#define BUTTON_PIN 33
+
+// PWM Configuration for Buzzer
+#define BUZZER_CHANNEL 0
+#define BUZZER_FREQ 2000
+#define BUZZER_RES 8
+
+void initHardware();
+
+// OLED Display Functions
+void displayStatus(const char *statusStr, const char *detailStr = "");
+void displayError(const char *errorStr);
+
+// LED Functions
+enum LedColor { LED_OFF, LED_RED, LED_BLUE, LED_BLUE_BLINK };
+void setLedState(LedColor color);
+void updateLedBlink(); // Call this in loop()
+
+// Buzzer Functions
+void playBeep(int durationMs);
+void playErrorSound();
+
+#endif

--- a/edge/src/main.cpp
+++ b/edge/src/main.cpp
@@ -1,4 +1,6 @@
+#include "HardwareConfig.h"
 #include <Arduino.h>
+#include <Bounce2.h>
 #include <Preferences.h>
 #include <WiFiManager.h>
 
@@ -18,22 +20,29 @@ char apiKey[64] = "your_api_key_here";
 
 bool shouldSaveConfig = false;
 
+// 稼働ステート管理
+enum TimerState { STATE_STANDBY, STATE_RUNNING };
+TimerState currentState = STATE_STANDBY;
+
+// ボタンのデバウンス用インスタンス
+Bounce debouncer = Bounce();
+
 // WiFiManagerの設定が保存された際に呼ばれるコールバック
 void saveConfigCallback() {
   Serial.println("Should save config");
   shouldSaveConfig = true;
 }
 
-// ... (後続のIssue
-// 5で定義予定ですが、今回はリセット用にボタンのピン定義を先行追加します)
-const int BUTTON_PIN = 33;
-
 void setup() {
   Serial.begin(115200);
   Serial.println("\n\nStarting ColorTimer Next...");
 
-  // 初期化リセット用ボタンの設定
-  pinMode(BUTTON_PIN, INPUT_PULLUP);
+  // ハードウェアピン等の初期化 (OLED, LED, Buzzer)
+  initHardware();
+
+  // 初期化リセット用ボタンの設定とBounce2へのアタッチ
+  debouncer.attach(BUTTON_PIN, INPUT_PULLUP);
+  debouncer.interval(25); // 25msのデバウンス
 
   // Preferencesの初期化 (読み書きモード)
   preferences.begin(PREF_NAMESPACE, false);
@@ -43,25 +52,27 @@ void setup() {
   wm.setSaveConfigCallback(saveConfigCallback);
 
   // 起動時にボタン(GPIO33)がLOW(押されている状態)なら設定を初期化する
-  // 誤動作防止のため、少し待ってから再度判定する
-  delay(100);
-  if (digitalRead(BUTTON_PIN) == LOW) {
+  debouncer.update();
+  if (debouncer.read() == LOW) {
+    displayStatus("RESETTING", "Clearing Settings");
     Serial.println("Reset button is pressed! Clearing all settings...");
-    // Preferences (フラッシュメモリの独自保存データ) をクリア
+    playBeep(500);
     preferences.clear();
-    // WiFiManager (Wi-Fi資格情報) をクリア
     wm.resetSettings();
+    displayStatus("CLEARED", "Please Reboot.");
     Serial.println(
         "Settings cleared. Please connect to 'ColorTimer-AP' to reconfigure.");
+    while (true) {
+      delay(100);
+    } // 停止
   }
 
-  // フラッシュメモリからの設定読み出し (存在しなければデフォルト値)
+  // フラッシュメモリからの設定読み出し
   String savedDeviceId = preferences.getString(PREF_DEVICE_ID, deviceId);
   String savedApiEndpoint =
       preferences.getString(PREF_API_ENDPOINT, apiEndpoint);
   String savedApiKey = preferences.getString(PREF_API_KEY, apiKey);
 
-  // Stringオブジェクトからchar配列へのコピー
   strlcpy(deviceId, savedDeviceId.c_str(), sizeof(deviceId));
   strlcpy(apiEndpoint, savedApiEndpoint.c_str(), sizeof(apiEndpoint));
   strlcpy(apiKey, savedApiKey.c_str(), sizeof(apiKey));
@@ -76,12 +87,14 @@ void setup() {
   wm.addParameter(&custom_api_endpoint);
   wm.addParameter(&custom_api_key);
 
-  // Wi-Fi接続の試行。接続情報がないか失敗した場合は ColorTimer-AP
-  // というアクセスポイントを起動する
+  displayStatus("Wi-Fi Setup", "Connecting...");
+
+  // Wi-Fi接続の試行。接続情報がないか失敗した場合はColorTimer-APというアクセスポイントを起動する
   if (!wm.autoConnect("ColorTimer-AP", "password")) {
+    displayError("Wi-Fi Failed");
     Serial.println("Failed to connect and hit timeout");
+    playErrorSound();
     delay(3000);
-    // リセットして再試行
     ESP.restart();
   }
 
@@ -98,14 +111,47 @@ void setup() {
     Serial.println("Configuration saved to Preferences.");
   }
 
-  Serial.println("");
-  Serial.println("Connected to Wi-Fi!");
-  Serial.print("IP Address: ");
-  Serial.println(WiFi.localIP());
-  Serial.printf("Device ID: %s\n", deviceId);
+  Serial.println("\nConnected to Wi-Fi!");
+  displayStatus("Connected!");
+  playBeep(100);
+  delay(100);
+  playBeep(100);
+
+  // 初期ステート: Standby
+  currentState = STATE_STANDBY;
+  setLedState(LED_BLUE_BLINK);
+  displayStatus("STANDBY", "Ready to Start");
 }
 
 void loop() {
-  // メインループ(ボタン検知、LED制御、HTTPリクエスト等)はIssue5、 Issue6で実装
-  delay(100);
+  // LEDの点滅更新
+  updateLedBlink();
+
+  // ボタンの状態を更新
+  debouncer.update();
+
+  // ボタンが押された（立ち下がりエッジ）時の処理
+  if (debouncer.fell()) {
+    if (currentState == STATE_STANDBY) {
+      // Standby -> Running
+      currentState = STATE_RUNNING;
+      setLedState(LED_RED);
+      displayStatus("RUNNING", "Working...");
+      playBeep(200); // ピッ
+      Serial.println("[Action] Timer Started");
+      // TODO: Issue 6でHTTP POST処理を追加 ('start')
+    } else {
+      // Running -> Standby
+      currentState = STATE_STANDBY;
+      setLedState(LED_BLUE_BLINK);
+      displayStatus("STANDBY", "Task Stopped.");
+      playBeep(100);
+      delay(100);
+      playBeep(100); // ピピッ
+      Serial.println("[Action] Timer Stopped");
+      // TODO: Issue 6でHTTP POST処理を追加 ('stop')
+    }
+  }
+
+  delay(10);
 }


### PR DESCRIPTION
Closes #9

## 概要
ColorTimer NextのESP32エッジデバイスにおいて、物理的なユーザーインターフェースとなる各ハードウェアコンポーネントの制御ロジックを実装しました。

- 追加ライブラリ:
  - `Adafruit SSD1306` / `Adafruit GFX Library` (OLEDディスプレイ制御用)
  - `Bounce2` (タクトスイッチのチャタリング除去用)
- 実装内容 (`edge/src/HardwareConfig.h/cpp`, `main.cpp`):
  - I2C (SDA:21, SCL:22) 接続のSSD1306 OLEDへのステータス描画
  - 赤色 (GPIO 25)・青色 (GPIO 26) LEDの点灯および点滅（Timer非同期）制御
  - GPIO 27に接続したブザーのPWM鳴動制御 (成功音、エラー音など)
  - GPIO 33に接続したボタンの立ち下がり検地によるステータス遷移機構 (STANDBY ⇔ RUNNING) の実装
  - (おまけ: #8 で実装した初期化機能のボタンについても Bounce2 経由へ修正済)

ローカルにて `pio run` ビルド通過確認済みです。
レビュー・マージのほどよろしくお願いします。
