### PR TITLE
[Frontend/Infra] Basic認証の設定と管理スクリプト作成 (#15)

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -184,12 +184,14 @@ Resources:
             var request = event.request;
             var headers = request.headers;
             
-            // default: admin:password
-            var expectedAuth = "Basic YWRtaW46cGFzc3dvcmQ=";
+            // Allow multiple users
+            var validAuths = [
+                "Basic YWRtaW46cGFzc3dvcmQ=" // admin:password
+            ];
             
             if (
                 !headers.authorization ||
-                headers.authorization.value !== expectedAuth
+                validAuths.indexOf(headers.authorization.value) === -1
             ) {
                 return {
                     statusCode: 401,

--- a/scripts/aws/manage-basic-auth.sh
+++ b/scripts/aws/manage-basic-auth.sh
@@ -4,25 +4,49 @@ set -e
 # リポジトリのルートディレクトリへ移動
 cd "$(dirname "$0")/../.."
 
-if [ "$#" -ne 2 ]; then
-    echo "Usage: ./scripts/aws/manage-basic-auth.sh <username> <password>"
+if [ "$#" -ne 3 ]; then
+    echo "Usage: ./scripts/aws/manage-basic-auth.sh [add|remove] <username> <password>"
+    echo "Example: ./scripts/aws/manage-basic-auth.sh add user1 pass1"
     exit 1
 fi
 
-USER=$1
-PASS=$2
+ACTION=$1
+USER=$2
+PASS=$3
 # Mac/Linux両対応のbase64エンコード
 AUTH_B64=$(printf "%s:%s" "$USER" "$PASS" | base64)
+AUTH_STRING="\"Basic ${AUTH_B64}\""
 
-echo "Updating template.yaml with new credentials..."
+TEMPLATE_FILE="backend/template.yaml"
 
-# backend/template.yaml の中の expectedAuth をsedで直接書き換える
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  # Mac
-  sed -i '' "s/var expectedAuth = \"Basic .*\";/var expectedAuth = \"Basic ${AUTH_B64}\";/" backend/template.yaml
+if [ "$ACTION" == "add" ]; then
+    echo "Adding/Updating user '$USER'..."
+    # 既に存在する場合は無視する簡易的なチェック
+    if grep -q "$AUTH_STRING" "$TEMPLATE_FILE"; then
+        echo "User '$USER' is already configured."
+    else
+        # 簡易的に配列の最後の要素か、先頭に追加する (sed等で無理やり挿入)
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          sed -i '' -e "/var validAuths = \[/a\\
+                $AUTH_STRING,
+" "$TEMPLATE_FILE"
+        else
+          sed -i "/var validAuths = \[/a\                $AUTH_STRING," "$TEMPLATE_FILE"
+        fi
+        echo "User '$USER' added successfully."
+    fi
+
+elif [ "$ACTION" == "remove" ]; then
+    echo "Removing user '$USER'..."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sed -i '' -e "/$AUTH_STRING/d" "$TEMPLATE_FILE"
+    else
+      sed -i "/$AUTH_STRING/d" "$TEMPLATE_FILE"
+    fi
+    echo "User '$USER' removed."
 else
-  # Linux
-  sed -i "s/var expectedAuth = \"Basic .*\";/var expectedAuth = \"Basic ${AUTH_B64}\";/" backend/template.yaml
+    echo "Invalid action. Use 'add' or 'remove'."
+    exit 1
 fi
 
 echo "Credentials updated locally in backend/template.yaml."


### PR DESCRIPTION
Closes #15

## 概要
ColorTimer Nextのフロントエンド環境へアクセス制限をかけるため、CloudFront Functionsを使用したBasic認証の実装と、その認証情報を更新するための管理用スクリプトを作成しました。

- コンポーネントおよび設定:
  - `backend/template.yaml` 内に `AWS::CloudFront::Function` (BasicAuthFunction) を新設しました。
  - フロントエンド用CloudFront (`FrontendDistribution`) の `DefaultCacheBehavior` / `viewer-request` イベントフックへ上記の関数をアタッチし、すべてのリクエストに対しBasic認証を要求するようにしました（デフォルト ID/PW: admin/password）。
  - `scripts/aws/manage-basic-auth.sh` を作成しました。
    - `manage-basic-auth.sh <username> <password>` と実行することで、Mac/Linux問わず自動でBase64エンコードし、`template.yaml`内のBasic認証パスワード文字列を書き換えられるようにしています。書き換え後、`sam deploy` を行うことで動的に適用できます。

## 確認事項
SAMテンプレートの検証 (`sam validate`) にパスしています。
レビュー・マージをお願いいたします。
