### PR TITLE
[Edge] シリアルモニタへの定期ステータスログ追加

### DIFF
--- a/edge/src/main.cpp
+++ b/edge/src/main.cpp
@@ -193,6 +193,17 @@ void loop() {
   // LEDの点滅更新
   updateLedBlink();
 
+  // 5秒ごとに現在のステータスをシリアルへ出力
+  static unsigned long lastStatusLog = 0;
+  if (millis() - lastStatusLog >= 5000) {
+    lastStatusLog = millis();
+    if (currentState == STATE_RUNNING) {
+      Serial.println("[STATUS] 状態: 作業中 (RUNNING) | LED: 赤点灯");
+    } else {
+      Serial.println("[STATUS] 状態: 休み中 (STANDBY) | LED: 青点滅");
+    }
+  }
+
   // ボタンの状態を更新
   debouncer.update();
 


### PR DESCRIPTION
Closes #22 (部分対応)

## 変更内容
`edge/src/main.cpp` の `loop()` に、5秒ごとに現在のステータスをシリアルモニタへ出力するデバッグログを追加しました。

- `STATE_STANDBY` のとき: `[STATUS] 状態: 休み中 (STANDBY) | LED: 青点滅`
- `STATE_RUNNING` のとき: `[STATUS] 状態: 作業中 (RUNNING) | LED: 赤点灯`

## 確認方法
ESP32にファームウェアを書き込み後、`pio device monitor` で確認できます。