### PR TITLE
[Bug Fix] receiver Lambdaの action バリデーション修正 (stop対応) (#25)

### DIFF
--- a/backend/src/receiver/app.mjs
+++ b/backend/src/receiver/app.mjs
@@ -20,8 +20,8 @@ export const handler = async (event) => {
         const { device_id, action } = body;
 
         // バリデーション
-        if (!device_id || !action || !['start', 'end'].includes(action)) {
-            return buildResponse(400, { message: "Invalid payload. 'device_id' and 'action' ('start' or 'end') are required." });
+        if (!device_id || !action || !['start', 'stop'].includes(action)) {
+            return buildResponse(400, { message: "Invalid payload. 'device_id' and 'action' ('start' or 'stop') are required." });
         }
 
         // サーバー時刻（開始・終了時点のタイムスタンプ）


### PR DESCRIPTION
Closes #25

## 修正内容
ESP32が送信する action の値が 'stop' なのに、Lambdaが 'end' のみ許可しており400エラーが発生していた。

- Before: [''start', 'end']
- After: ['start', 'stop']