### PR TITLE
[Bug Fix] OPTIONSメソッドでのAPIキー要求を除外 (CORSエラー修正)

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -47,7 +47,6 @@ Resources:
         AllowHeaders: "'Content-Type,X-Api-Key'"
         AllowMethods: "'GET,POST,OPTIONS'"
       Auth:
-        ApiKeyRequired: true # 全メソッドに対してデフォルトでAPIキーを要求する
         UsagePlan:
           CreateUsagePlan: PER_API
           Description: "ColorTimerNext Usage Plan"
@@ -76,6 +75,8 @@ Resources:
             RestApiId: !Ref ColorTimerApi
             Method: POST
             Path: /api/logs
+            Auth:
+              ApiKeyRequired: true
 
   # ----------------------------------------------------------------------
   # Fetcher Lambda Function (Get Logs for Dashboard)
@@ -101,6 +102,8 @@ Resources:
             RestApiId: !Ref ColorTimerApi
             Method: GET
             Path: /api/logs
+            Auth:
+              ApiKeyRequired: true
 
   # ----------------------------------------------------------------------
   # Frontend S3 Bucket


### PR DESCRIPTION
## 修正内容
API GatewayのグローバルAuth設定で `ApiKeyRequired: true` としていたため、ブラウザからのプリフライト(OPTIONS)リクエストもAPIキーを要求されてしまい、403エラー(CORSエラーとしてブラウザで表示)になっていました。

- グローバル設定から `ApiKeyRequired: true` を削除
- 代わりに各Lambda (POST, GET) のイベント設定レベルに `ApiKeyRequired: true` を移動