### PR TITLE
[Edge] 動作時のLED仕様変更とタイムアウト機能の追加 (#29)

### DIFF
--- a/edge/src/HardwareConfig.cpp
+++ b/edge/src/HardwareConfig.cpp
@@ -82,8 +82,12 @@ void setLedState(LedColor color) {
     digitalWrite(LED_BLUE_PIN, HIGH);
     break;
   case LED_BLUE_BLINK:
-    // Initial state is on, toggle logic handled in updateLedBlink()
     digitalWrite(LED_BLUE_PIN, HIGH);
+    ledToggleState = true;
+    lastBlinkTime = millis();
+    break;
+  case LED_RED_BLINK:
+    digitalWrite(LED_RED_PIN, HIGH);
     ledToggleState = true;
     lastBlinkTime = millis();
     break;
@@ -99,6 +103,12 @@ void updateLedBlink() {
       ledToggleState = !ledToggleState;
       digitalWrite(LED_BLUE_PIN, ledToggleState ? HIGH : LOW);
     }
+  } else if (currentLedState == LED_RED_BLINK) {
+    if (millis() - lastBlinkTime >= 250) { // Toggle faster (250ms)
+      lastBlinkTime = millis();
+      ledToggleState = !ledToggleState;
+      digitalWrite(LED_RED_PIN, ledToggleState ? HIGH : LOW);
+    }
   }
 }
 
@@ -112,5 +122,34 @@ void playErrorSound() {
   for (int i = 0; i < 3; i++) {
     playBeep(100);
     delay(100);
+  }
+}
+
+// タイムアウト時のカラータイマー音（徐々に早くなる）
+// ※ 呼び出し元で delay
+// を挟まないよう、内部で時間を管理して1回分の「ピコン」を鳴らすか判定
+void playColorTimerSound() {
+  static unsigned long lastSoundTime = 0;
+  static int beepInterval = 1000; // 初期インターバル(ms)
+  static int beepCount = 0;
+
+  if (millis() - lastSoundTime >= beepInterval) {
+    lastSoundTime = millis();
+
+    // ピ・コン (高低音)
+    ledcWriteTone(BUZZER_CHANNEL, 1500); // 高音
+    delay(100);
+    ledcWriteTone(BUZZER_CHANNEL, 1000); // 低音
+    delay(150);
+    ledcWrite(BUZZER_CHANNEL, 0); // 停止
+    // 元の周波数にリセット
+    ledcSetup(BUZZER_CHANNEL, BUZZER_FREQ, BUZZER_RES);
+
+    beepCount++;
+
+    // だんだん早くする（最小200msまで）
+    if (beepCount % 5 == 0 && beepInterval > 200) {
+      beepInterval -= 150;
+    }
   }
 }

--- a/edge/src/HardwareConfig.h
+++ b/edge/src/HardwareConfig.h
@@ -23,12 +23,13 @@ void displayStatus(const char *statusStr, const char *detailStr = "");
 void displayError(const char *errorStr);
 
 // LED Functions
-enum LedColor { LED_OFF, LED_RED, LED_BLUE, LED_BLUE_BLINK };
+enum LedColor { LED_OFF, LED_RED, LED_BLUE, LED_BLUE_BLINK, LED_RED_BLINK };
 void setLedState(LedColor color);
 void updateLedBlink(); // Call this in loop()
 
 // Buzzer Functions
 void playBeep(int durationMs);
 void playErrorSound();
+void playColorTimerSound(); // タイムアウト用カラータイマー音
 
 #endif

--- a/edge/src/main.cpp
+++ b/edge/src/main.cpp
@@ -13,19 +13,23 @@ Preferences preferences;
 const char *PREF_NAMESPACE = "colortimer";
 const char *PREF_DEVICE_ID = "device_id";
 const char *PREF_API_ENDPOINT = "api_endpt";
-const char *PREF_API_KEY = "api_key";
+const char *PREF_TIMEOUT_MIN = "timeout_min";
 
 // メモリ保持用変数 (初期値)
 char deviceId[32] = "esp32-timer-default";
 char apiEndpoint[128] =
     "https://********.execute-api.ap-northeast-1.amazonaws.com/prod/api/logs";
 char apiKey[64] = "your_api_key_here";
+char timeoutMin[8] = "30"; // デフォルト30分
 
 bool shouldSaveConfig = false;
 
 // 稼働ステート管理
-enum TimerState { STATE_STANDBY, STATE_RUNNING };
+enum TimerState { STATE_STANDBY, STATE_RUNNING, STATE_TIMEOUT };
 TimerState currentState = STATE_STANDBY;
+
+// 長押し機能やタイムアウト計算用
+unsigned long stateStartTime = 0;
 
 // ボタンのデバウンス用インスタンス
 Bounce debouncer = Bounce();
@@ -138,20 +142,25 @@ void setup() {
   String savedApiEndpoint =
       preferences.getString(PREF_API_ENDPOINT, apiEndpoint);
   String savedApiKey = preferences.getString(PREF_API_KEY, apiKey);
+  String savedTimeoutMin = preferences.getString(PREF_TIMEOUT_MIN, timeoutMin);
 
   strlcpy(deviceId, savedDeviceId.c_str(), sizeof(deviceId));
   strlcpy(apiEndpoint, savedApiEndpoint.c_str(), sizeof(apiEndpoint));
   strlcpy(apiKey, savedApiKey.c_str(), sizeof(apiKey));
+  strlcpy(timeoutMin, savedTimeoutMin.c_str(), sizeof(timeoutMin));
 
   // カスタムパラメータの設定
   WiFiManagerParameter custom_device_id("device_id", "Device ID", deviceId, 32);
   WiFiManagerParameter custom_api_endpoint("api_endpoint", "API Endpoint URL",
                                            apiEndpoint, 128);
   WiFiManagerParameter custom_api_key("api_key", "API Gateway Key", apiKey, 64);
+  WiFiManagerParameter custom_timeout_min("timeout_min", "Timeout (minutes)",
+                                          timeoutMin, 8);
 
   wm.addParameter(&custom_device_id);
   wm.addParameter(&custom_api_endpoint);
   wm.addParameter(&custom_api_key);
+  wm.addParameter(&custom_timeout_min);
 
   displayStatus("Wi-Fi Setup", "Connecting...");
 
@@ -169,10 +178,12 @@ void setup() {
     strlcpy(deviceId, custom_device_id.getValue(), sizeof(deviceId));
     strlcpy(apiEndpoint, custom_api_endpoint.getValue(), sizeof(apiEndpoint));
     strlcpy(apiKey, custom_api_key.getValue(), sizeof(apiKey));
+    strlcpy(timeoutMin, custom_timeout_min.getValue(), sizeof(timeoutMin));
 
     preferences.putString(PREF_DEVICE_ID, deviceId);
     preferences.putString(PREF_API_ENDPOINT, apiEndpoint);
     preferences.putString(PREF_API_KEY, apiKey);
+    preferences.putString(PREF_TIMEOUT_MIN, timeoutMin);
 
     Serial.println("Configuration saved to Preferences.");
   }
@@ -185,7 +196,8 @@ void setup() {
 
   // 初期ステート: Standby
   currentState = STATE_STANDBY;
-  setLedState(LED_BLUE_BLINK);
+  setLedState(LED_RED); // 待機＝赤点灯
+  displayStatus("STANDBY", "Ready to Start");
   displayStatus("STANDBY", "Ready to Start");
 }
 
@@ -198,10 +210,29 @@ void loop() {
   if (millis() - lastStatusLog >= 5000) {
     lastStatusLog = millis();
     if (currentState == STATE_RUNNING) {
-      Serial.println("[STATUS] 状態: 作業中 (RUNNING) | LED: 赤点灯");
+      Serial.println("[STATUS] 状態: 作業中 (RUNNING) | LED: 青点灯");
+    } else if (currentState == STATE_TIMEOUT) {
+      Serial.println(
+          "[STATUS] 状態: タイムアウト (TIMEOUT) | LED: 青点滅 & アラーム");
     } else {
-      Serial.println("[STATUS] 状態: 休み中 (STANDBY) | LED: 青点滅");
+      Serial.println("[STATUS] 状態: 休み中 (STANDBY) | LED: 赤点灯");
     }
+  }
+
+  // タイムアウト検知処理
+  if (currentState == STATE_RUNNING) {
+    long timeoutMs = atol(timeoutMin) * 60 * 1000;
+    if (millis() - stateStartTime >= timeoutMs) {
+      currentState = STATE_TIMEOUT;
+      setLedState(LED_BLUE_BLINK); // タイムアウト＝青点滅
+      displayStatus("TIMEOUT", "Time's up!");
+      Serial.println("[Action] Timer Timeout Reached");
+    }
+  }
+
+  // タイムアウト状態ならカラータイマー音を非同期で鳴らす
+  if (currentState == STATE_TIMEOUT) {
+    playColorTimerSound();
   }
 
   // ボタンの状態を更新
@@ -214,7 +245,8 @@ void loop() {
       displayStatus("Sending...", "Start Timer");
       if (sendLogToApi("start")) {
         currentState = STATE_RUNNING;
-        setLedState(LED_RED);
+        stateStartTime = millis(); // 開始時間を記録
+        setLedState(LED_BLUE);     // 作業中＝青点灯
         displayStatus("RUNNING", "Working...");
         playBeep(200); // 成功音ピッ
         Serial.println("[Action] Timer Started");
@@ -225,12 +257,13 @@ void loop() {
         displayStatus("STANDBY", "Ready to Start");
       }
 
-    } else {
-      // Running -> Standby (Stop API Request)
+    } else if (currentState == STATE_RUNNING || currentState == STATE_TIMEOUT) {
+      // Running/Timeout -> Standby (Stop API Request)
       displayStatus("Sending...", "Stop Timer");
       if (sendLogToApi("stop")) {
         currentState = STATE_STANDBY;
-        setLedState(LED_BLUE_BLINK);
+        // タイムアウト用音のリセットのため、LEDと同様に状態をリセット
+        setLedState(LED_RED); // 待機＝赤点灯に戻る
         displayStatus("STANDBY", "Task Stopped.");
         playBeep(100);
         delay(100);


### PR DESCRIPTION
Closes #29

## 実装内容
- **LED仕様変更**:
  - 待機中(STANDBY): 赤点灯 (以前は青点滅)
  - 作業中(RUNNING): 青点灯 (以前は赤点灯)
- **タイムアウト機能**:
  - WiFiManager の設定ポータルに `timeout_min` パラメータを追加（デフォルト30分）
  - 指定時間を経過すると `STATE_TIMEOUT` ステートへ移行
  - タイムアウト時は **青点滅** ＆ **徐々に早くなるカラータイマー音** を鳴らす
  - (※LED赤点滅 `LED_RED_BLINK` も実装したが仕様により青点滅を採用)