### PR TITLE
fix: 完全初期化で Preferences も消去する

### DIFF
--- a/edge/src/main.cpp
+++ b/edge/src/main.cpp
@@ -94,6 +94,11 @@ bool ensureSystemTimeSync() {
   return false;
 }
 
+void clearStoredSettings(WiFiManager &wm) {
+  preferences.clear();
+  wm.resetSettings();
+}
+
 // WiFiManagerの設定が保存された際に呼ばれるコールバック
 void saveConfigCallback() {
   Serial.println("Should save config");
@@ -190,8 +195,7 @@ void setup() {
     displayStatus("RESETTING", "Clearing Settings");
     Serial.println("Reset button is pressed! Clearing all settings...");
     playBeep(500);
-    preferences.clear();
-    wm.resetSettings();
+    clearStoredSettings(wm);
     displayStatus("CLEARED", "Please Reboot.");
     Serial.println(
         "Settings cleared. Please connect to 'ColorTimer-AP' to reconfigure.");
@@ -345,9 +349,11 @@ void loop() {
     if (pressedDuration >= 5000) {
       // 5秒以上長押し -> 完全初期化
       Serial.println("[Action] Reset to default settings");
-      displayStatus("RESETTING...", "Clearing WiFi");
+      displayStatus("RESETTING", "Clearing Settings");
       WiFiManager wm;
-      wm.resetSettings();
+      clearStoredSettings(wm);
+      Serial.println(
+          "[Action] Settings cleared. Restarting into initial setup state.");
       delay(1000);
       ESP.restart(); // 再起動して初期状態へ
     } else if (pressedDuration >= 3000) {


### PR DESCRIPTION
## 概要
- 5 秒長押しの完全初期化でも `Preferences` を消去するようにして、起動時初期化と同じ動作に統一
- 設定消去処理を `clearStoredSettings` にまとめて、Wi-Fi 設定とアプリ設定の消去を常に同じ経路で実行
- 表示文言を `Clearing WiFi` から `Clearing Settings` に変更し、実際の挙動と合わせた

## 確認内容
- `pio run`

## 補足
- 実機での 5 秒長押し確認はこの環境からは行っていません。

Closes #36